### PR TITLE
fix: use WebsocketServer instead of the Server alias

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -2,7 +2,7 @@
 
 import { generateUniqueNumber } from 'fast-unique-numbers';
 import { argv } from 'process';
-import ws from 'ws';
+import { WebSocketServer } from 'ws';
 import yargs from 'yargs';
 import { ICommandLineArguments } from './interfaces';
 
@@ -22,7 +22,7 @@ import { ICommandLineArguments } from './interfaces';
 
     const { port } = commandLineArguments;
     const activeConnections = new Map<number, (message: object) => void>();
-    const server = new ws.Server({ port });
+    const server = new WebSocketServer({ port });
 
     server.on('connection', (connection) => {
         const id = generateUniqueNumber(activeConnections);


### PR DESCRIPTION
hey chris, 

the latest version gave me an `ws.Server is not a constructor` error. Turns out that `Server` is not exported from the ws ESM wrapper as stated here https://github.com/websockets/ws/issues/1932#issuecomment-899085174. And since you switched your build to es module this became an issue. the PR should fix it.